### PR TITLE
Fixed issue in Python 3 server

### DIFF
--- a/backends/python3_server.py
+++ b/backends/python3_server.py
@@ -10,7 +10,7 @@ DB = MyDB()
 class DebuggerPeer(PingPong):
 	def D_set_breakpoints(self, bps          ):
 		for ldict in bps.values():
-			for k in ldict.keys():
+			for k in list(ldict):
 				ldict[int(k)] = ldict[k]
 				ldict.pop(k)
 		DB.breakpoints = bps


### PR DESCRIPTION
In Python 2.x calling keys() makes a copy of the keys of the dictionary.
In Python 3.x returns an iterator instead, which leads to Runtime Errors
when the dictionary is changed while iterating over its keys.